### PR TITLE
Download and upload progress is shown (v1)

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -30,7 +30,7 @@ var state = 'ping';
 var frame = elegantSpinner();
 
 function getSpinner(x) {
-	return state === x ? chalk.cyan.dim(frame()) : '';
+	return state === x ? chalk.cyan.dim(frame()) : ' ';
 }
 
 function render() {
@@ -41,9 +41,9 @@ function render() {
 
 	logUpdate([
 		'',
-		'      Ping  ' + stats.ping + getSpinner('ping'),
-		'  Download  ' + stats.download + getSpinner('download'),
-		'    Upload  ' + stats.upload + getSpinner('upload')
+		getSpinner('ping') +		'     Ping ' + stats.ping,
+		getSpinner('download') + 	' Download ' + stats.download,
+		getSpinner('upload') +		'   Upload ' + stats.upload
 	].join('\n'));
 }
 
@@ -57,6 +57,20 @@ st.once('testserver', function (server) {
 	state = 'download';
 	var ping = Math.round(server.bestPing);
 	stats.ping = (cli.flags.json) ? ping : chalk.cyan(ping + chalk.dim(' ms'));
+});
+
+st.on('downloadspeedprogress', function (speed) {
+	if (state === 'download') {
+		var download = roundTo(speed, 1);
+		stats.download = (cli.flags.json) ? download : chalk.yellow(download + chalk.dim(' Mbps'));
+	}
+});
+
+st.on('uploadspeedprogress', function (speed) {
+	if (state === 'upload') {
+		var upload = roundTo(speed, 1);
+		stats.upload = (cli.flags.json) ? upload : chalk.yellow(upload + chalk.dim(' Mbps'));
+	}
 });
 
 st.once('downloadspeed', function (speed) {

--- a/cli.js
+++ b/cli.js
@@ -41,9 +41,9 @@ function render() {
 
 	logUpdate([
 		'',
-		getSpinner('ping') +		'     Ping ' + stats.ping,
-		getSpinner('download') + 	' Download ' + stats.download,
-		getSpinner('upload') +		'   Upload ' + stats.upload
+		getSpinner('ping') +		'     Ping  ' + stats.ping,
+		getSpinner('download') + 	' Download  ' + stats.download,
+		getSpinner('upload') +		'   Upload  ' + stats.upload
 	].join('\n'));
 }
 

--- a/cli.js
+++ b/cli.js
@@ -60,16 +60,16 @@ st.once('testserver', function (server) {
 });
 
 st.on('downloadspeedprogress', function (speed) {
-	if (state === 'download') {
+	if (state === 'download' && cli.flags.json !== true) {
 		var download = roundTo(speed, 1);
-		stats.download = (cli.flags.json) ? download : chalk.yellow(download + chalk.dim(' Mbps'));
+		stats.download = chalk.yellow(download + chalk.dim(' Mbps'));
 	}
 });
 
 st.on('uploadspeedprogress', function (speed) {
-	if (state === 'upload') {
+	if (state === 'upload' && cli.flags.json !== true) {
 		var upload = roundTo(speed, 1);
-		stats.upload = (cli.flags.json) ? upload : chalk.yellow(upload + chalk.dim(' Mbps'));
+		stats.upload = chalk.yellow(upload + chalk.dim(' Mbps'));
 	}
 });
 


### PR DESCRIPTION
The intermediate download and upload progress is shown as requested in #7.

As long as the stage is not finished yet, the progress is shown in yellow. The reason I moved the spinner to the front is because I couldn't find a nice way of formatting by keeping the spinner at the end or somewhere in the middle.

Another option can be found in PR https://github.com/sindresorhus/speed-test/pull/20. Just merge whatever you like :).

![screen shot 2015-09-28 at 19 30 16](https://cloud.githubusercontent.com/assets/1913805/10143235/6395ab74-6617-11e5-8309-089197d1395d.png)
![screen shot 2015-09-28 at 19 29 27](https://cloud.githubusercontent.com/assets/1913805/10143238/661dce3a-6617-11e5-8f2e-3918c93fef1f.png)
![screen shot 2015-09-28 at 19 29 47](https://cloud.githubusercontent.com/assets/1913805/10143240/684b6faa-6617-11e5-91af-10b1a6d2ec85.png)

