### PR TITLE
Add --verbose flag

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -7,6 +7,7 @@ var roundTo = require('round-to');
 var chalk = require('chalk');
 var logUpdate = require('log-update');
 var elegantSpinner = require('elegant-spinner');
+var url = require('url');
 
 var cli = meow({
 	help: [
@@ -52,7 +53,7 @@ function render() {
 			'',
 			'    Server   ' + chalk.cyan(stats.data.server.host),
 			'  Location   ' + chalk.cyan(stats.data.server.location + chalk.dim(' (' + stats.data.server.country + ')')),
-			'  Distance   ' + chalk.cyan(stats.data.server.distance + chalk.dim(' km'))
+			'  Distance   ' + chalk.cyan(roundTo(stats.data.server.distance, 1) + chalk.dim(' km'))
 		]);
 	}
 
@@ -67,6 +68,14 @@ function setState(s) {
 	}
 }
 
+function map(server) {
+	server.host = url.parse(server.url).host;
+	server.location = server.name;
+	server.distance = server.dist;
+
+	return server;
+}
+
 var st = speedtest({maxTime: 20000});
 
 if (!cli.flags.json) {
@@ -74,6 +83,12 @@ if (!cli.flags.json) {
 }
 
 st.once('testserver', function (server) {
+	if (cli.flags.verbose) {
+		stats.data = {
+			server: map(server)
+		};
+	}
+
 	setState('download');
 	var ping = Math.round(server.bestPing);
 	stats.ping = (cli.flags.json) ? ping : chalk.cyan(ping + chalk.dim(' ms'));
@@ -109,6 +124,7 @@ st.on('data', function (data) {
 	if (cli.flags.verbose) {
 		stats.data = data;
 	}
+
 	render();
 });
 

--- a/cli.js
+++ b/cli.js
@@ -48,12 +48,12 @@ function render() {
 		'    Upload ' + getSpinner('upload') + ' ' + stats.upload
 	];
 
-	if (cli.flags.verbose && stats.data) {
+	if (cli.flags.verbose) {
 		output = output.concat([
 			'',
-			'    Server   ' + chalk.cyan(stats.data.server.host),
-			'  Location   ' + chalk.cyan(stats.data.server.location + chalk.dim(' (' + stats.data.server.country + ')')),
-			'  Distance   ' + chalk.cyan(roundTo(stats.data.server.distance, 1) + chalk.dim(' km'))
+			'    Server   ' + (stats.data !== undefined ? chalk.cyan(stats.data.server.host) : ''),
+			'  Location   ' + (stats.data !== undefined ? chalk.cyan(stats.data.server.location + chalk.dim(' (' + stats.data.server.country + ')')) : ''),
+			'  Distance   ' + (stats.data !== undefined ? chalk.cyan(roundTo(stats.data.server.distance, 1) + chalk.dim(' km')) : '')
 		]);
 	}
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "log-update": "^1.0.0",
     "meow": "^3.3.0",
     "round-to": "^1.0.0",
-    "speedtest-net": "^1.0.3",
+    "speedtest-net": "^1.1.0",
     "update-notifier": "^0.5.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "update-notifier": "^0.5.0"
   },
   "devDependencies": {
-    "ava": "0.0.4",
+    "ava": "^0.2.0",
     "xo": "*"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,8 @@ $ speed-test --help
     $ speed-test
 
   Options
-    --json  Output the result as JSON
+    --json     Output the result as JSON
+    --verbose  Output more detailed information
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -2,12 +2,60 @@
 var test = require('ava');
 var childProcess = require('child_process');
 
-test(function (t) {
+test('normal', function (t) {
 	t.plan(1);
 
 	var cp = childProcess.spawn('./cli.js', {
 		cwd: __dirname,
 		stdio: 'inherit'
+	});
+
+	cp.on('error', function (err) {
+		t.assert(!err, err);
+	});
+
+	cp.on('close', function (code) {
+		t.assert(code === 0);
+	});
+});
+
+test('--json', function (t) {
+	t.plan(1);
+
+	var cp = childProcess.spawn('./cli.js', ['--json'], {
+		cwd: __dirname
+	});
+
+	cp.stdout.on('data', function (data) {
+		data = JSON.parse(data.toString('utf8'));
+
+		if (data.ping === undefined || data.upload === undefined || data.download === undefined || data.upload !== undefined) {
+			cp.kill('SIGHUP');
+		}
+	});
+
+	cp.on('error', function (err) {
+		t.assert(!err, err);
+	});
+
+	cp.on('close', function (code) {
+		t.assert(code === 0);
+	});
+});
+
+test('--verbose --json', function (t) {
+	t.plan(1);
+
+	var cp = childProcess.spawn('./cli.js', ['--verbose', '--json'], {
+		cwd: __dirname
+	});
+
+	cp.on('data', function (data) {
+		data = JSON.parse(data.toString('utf8'));
+
+		if (data.ping === undefined || data.upload === undefined || data.download === undefined || data.upload === undefined) {
+			cp.kill('SIGHUP');
+		}
 	});
 
 	cp.on('error', function (err) {

--- a/test.js
+++ b/test.js
@@ -20,49 +20,53 @@ test('main', function (t) {
 });
 
 test('--json', function (t) {
-	t.plan(1);
-
-	var cp = childProcess.spawn('./cli.js', ['--json'], {
+	var cp = childProcess.execFile('./cli.js', ['--json'], {
 		cwd: __dirname
 	});
 
+	cp.stdout.setEncoding('utf8');
 	cp.stdout.on('data', function (data) {
-		data = JSON.parse(data.toString('utf8'));
+		data = JSON.parse(data);
 
-		if (data.ping === undefined || data.upload === undefined || data.download === undefined || data.data !== undefined) {
-			cp.kill('SIGHUP');
-		}
+		t.false(data.ping === undefined);
+		t.false(data.upload === undefined);
+		t.false(data.download === undefined);
+		t.true(data.data === undefined);
 	});
 
 	cp.on('error', function (err) {
 		t.assert(!err, err);
+		t.end();
 	});
 
 	cp.on('close', function (code) {
 		t.assert(code === 0);
+		t.end();
 	});
 });
 
 test('--verbose --json', function (t) {
-	t.plan(1);
-
-	var cp = childProcess.spawn('./cli.js', ['--verbose', '--json'], {
+	var cp = childProcess.execFile('./cli.js', ['--verbose', '--json'], {
 		cwd: __dirname
 	});
 
+	cp.stdout.setEncoding('utf8');
 	cp.stdout.on('data', function (data) {
-		data = JSON.parse(data.toString('utf8'));
+		data = JSON.parse(data);
 
-		if (data.ping === undefined || data.upload === undefined || data.download === undefined || data.data === undefined) {
-			cp.kill('SIGHUP');
-		}
+		t.false(data.ping === undefined);
+		t.false(data.upload === undefined);
+		t.false(data.download === undefined);
+		t.false(data.data === undefined);
 	});
 
 	cp.on('error', function (err) {
 		t.assert(!err, err);
+		t.end();
 	});
 
 	cp.on('close', function (code) {
 		t.assert(code === 0);
+		t.end();
 	});
 });

--- a/test.js
+++ b/test.js
@@ -20,53 +20,35 @@ test('main', function (t) {
 });
 
 test('--json', function (t) {
-	var cp = childProcess.execFile('./cli.js', ['--json'], {
-		cwd: __dirname
-	});
+	childProcess.execFile('./cli.js', ['--json'], {cwd: __dirname, encoding: 'utf8'}, function (err, data) {
+		if (err) {
+			t.fail(err);
+		} else {
+			data = JSON.parse(data);
 
-	cp.stdout.setEncoding('utf8');
-	cp.stdout.on('data', function (data) {
-		data = JSON.parse(data);
+			t.false(data.ping === undefined);
+			t.false(data.upload === undefined);
+			t.false(data.download === undefined);
+			t.true(data.data === undefined);
+		}
 
-		t.false(data.ping === undefined);
-		t.false(data.upload === undefined);
-		t.false(data.download === undefined);
-		t.true(data.data === undefined);
-	});
-
-	cp.on('error', function (err) {
-		t.assert(!err, err);
-		t.end();
-	});
-
-	cp.on('close', function (code) {
-		t.assert(code === 0);
 		t.end();
 	});
 });
 
 test('--verbose --json', function (t) {
-	var cp = childProcess.execFile('./cli.js', ['--verbose', '--json'], {
-		cwd: __dirname
-	});
+	childProcess.execFile('./cli.js', ['--verbose', '--json'], {cwd: __dirname, encoding: 'utf8'}, function (err, data) {
+		if (err) {
+			t.fail(err);
+		} else {
+			data = JSON.parse(data);
 
-	cp.stdout.setEncoding('utf8');
-	cp.stdout.on('data', function (data) {
-		data = JSON.parse(data);
+			t.false(data.ping === undefined);
+			t.false(data.upload === undefined);
+			t.false(data.download === undefined);
+			t.false(data.data === undefined);
+		}
 
-		t.false(data.ping === undefined);
-		t.false(data.upload === undefined);
-		t.false(data.download === undefined);
-		t.false(data.data === undefined);
-	});
-
-	cp.on('error', function (err) {
-		t.assert(!err, err);
-		t.end();
-	});
-
-	cp.on('close', function (code) {
-		t.assert(code === 0);
 		t.end();
 	});
 });

--- a/test.js
+++ b/test.js
@@ -2,7 +2,7 @@
 var test = require('ava');
 var childProcess = require('child_process');
 
-test('normal', function (t) {
+test('main', function (t) {
 	t.plan(1);
 
 	var cp = childProcess.spawn('./cli.js', {

--- a/test.js
+++ b/test.js
@@ -29,7 +29,7 @@ test('--json', function (t) {
 	cp.stdout.on('data', function (data) {
 		data = JSON.parse(data.toString('utf8'));
 
-		if (data.ping === undefined || data.upload === undefined || data.download === undefined || data.upload !== undefined) {
+		if (data.ping === undefined || data.upload === undefined || data.download === undefined || data.data !== undefined) {
 			cp.kill('SIGHUP');
 		}
 	});
@@ -50,10 +50,10 @@ test('--verbose --json', function (t) {
 		cwd: __dirname
 	});
 
-	cp.on('data', function (data) {
+	cp.stdout.on('data', function (data) {
 		data = JSON.parse(data.toString('utf8'));
 
-		if (data.ping === undefined || data.upload === undefined || data.download === undefined || data.upload === undefined) {
+		if (data.ping === undefined || data.upload === undefined || data.download === undefined || data.data === undefined) {
 			cp.kill('SIGHUP');
 		}
 	});


### PR DESCRIPTION
Resolved issue https://github.com/sindresorhus/speed-test/issues/6 by adding the --verbose flag.

I also added extra tests for testing the json outputs. It seems that `t` does not work inside `cp.stdout.on('data', ...`. Is this in issue in `AVA` or not? I fixed it by calling kill if the json is not correct which will throw an error which will fail the test.

@sindresorhus I know I have access to the repo, but want your consent on this ;).