### PR TITLE
Print user-friendly error if internet is down

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -51,9 +51,9 @@ function render() {
 	if (cli.flags.verbose) {
 		output = output.concat([
 			'',
-			'    Server   ' + (stats.data !== undefined ? chalk.cyan(stats.data.server.host) : ''),
-			'  Location   ' + (stats.data !== undefined ? chalk.cyan(stats.data.server.location + chalk.dim(' (' + stats.data.server.country + ')')) : ''),
-			'  Distance   ' + (stats.data !== undefined ? chalk.cyan(roundTo(stats.data.server.distance, 1) + chalk.dim(' km')) : '')
+			'    Server   ' + (stats.data === undefined ? '' : chalk.cyan(stats.data.server.host)),
+			'  Location   ' + (stats.data === undefined ? '' : chalk.cyan(stats.data.server.location + chalk.dim(' (' + stats.data.server.country + ')'))),
+			'  Distance   ' + (stats.data === undefined ? '' : chalk.cyan(roundTo(stats.data.server.distance, 1) + chalk.dim(' km')))
 		]);
 	}
 

--- a/cli.js
+++ b/cli.js
@@ -133,6 +133,10 @@ st.on('done', function () {
 });
 
 st.on('error', function (err) {
-	console.error(err);
+	if (err.code === 'ENOTFOUND') {
+		console.log(chalk.bold.red('Error:'), 'please check your internet connection.');
+	} else {
+		console.error(err);
+	}
 	process.exit(1);
 });

--- a/cli.js
+++ b/cli.js
@@ -6,6 +6,7 @@ var updateNotifier = require('update-notifier');
 var roundTo = require('round-to');
 var chalk = require('chalk');
 var logUpdate = require('log-update');
+var logSymbols = require('log-symbols');
 var elegantSpinner = require('elegant-spinner');
 var url = require('url');
 
@@ -134,9 +135,10 @@ st.on('done', function () {
 
 st.on('error', function (err) {
 	if (err.code === 'ENOTFOUND') {
-		console.log(chalk.bold.red('Error:'), 'please check your internet connection.');
+		console.error(logSymbols.error, 'Please check your internet connection');
 	} else {
 		console.error(err);
 	}
+
 	process.exit(1);
 });

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "chalk": "^1.1.0",
     "elegant-spinner": "^1.0.0",
+    "log-symbols": "^1.0.2",
     "log-update": "^1.0.0",
     "meow": "^3.3.0",
     "round-to": "^1.0.0",


### PR DESCRIPTION
Yesterday my internet seemed very slow so I used `speed-test` to test it. It seemed my internet connection was down entirely and it couldn't reach the speed-test servers.

```
{ [Error: getaddrinfo ENOTFOUND www.speedtest.net www.speedtest.net:80]
  code: 'ENOTFOUND',
  errno: 'ENOTFOUND',
  syscall: 'getaddrinfo',
  hostname: 'www.speedtest.net',
  host: 'www.speedtest.net',
  port: 80 }
```

So I thought it would be a good idea to show a more user-friendly error if this happens. Feel free to suggest another error message or to not merge at all :).