### PR TITLE
Add the packaging metadata to build the speed-test snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: speed-test
+version: master
+summary: Test your internet connection speed and ping from the CLI
+description: |
+  Test your internet connection speed and ping using speedtest.net from the CLI
+
+grade: stable
+confinement: strict
+
+apps:
+  speed-test:
+    command: speed-test
+    plugs: [network]
+
+parts:
+  speed-test:
+    source: .
+    plugin: nodejs


### PR DESCRIPTION
This is a package for the secure installation of apps that works in most Linux distributions.
Landing it upstream will enable builds for adventurous users.