### PR TITLE
Display extra newline on exit

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -137,6 +137,7 @@ st.on('data', function (data) {
 });
 
 st.on('done', function () {
+	console.log();
 	process.exit();
 });
 


### PR DESCRIPTION
Now once the program exits there will be blank space above and below the data.