### PR TITLE
Upgrade speedtest.net dependency for PROXY support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "speed-test",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"description": "Test your internet connection speed and ping using speedtest.net from the CLI",
 	"license": "MIT",
 	"repository": "sindresorhus/speed-test",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"meow": "^4.0.0",
 		"ora": "^1.4.0",
 		"round-to": "^2.0.0",
-		"speedtest-net": "^1.2.4",
+		"speedtest-net": "^1.4.2",
 		"update-notifier": "^2.3.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
speedtest.net dependency has PROXY support via env-vars however
speed-test hasn't upgraded yet.  So adding via this commit to
allow PROXY in speed-test