### PR TITLE
Add timestamp to the JSON output

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -146,6 +146,7 @@ st.once('uploadspeed', speed => {
 
 st.on('data', data => {
 	if (cli.flags.verbose) {
+		stats.timestamp = new Date().getTime();
 		stats.data = data;
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,11 @@ $ speed-test --help
     --verbose -v  Output more detailed information
 ```
 
+## Batch monitoring
+
+```bash
+while true; do sleep 30; node cli.js -v -j; done >> ~/net.log
+```
 
 ## Links
 

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,8 @@ $ speed-test --help
 while true; do sleep 30; node cli.js --verbose --json; done >> ~/net.log
 ```
 
+**Note**: using the **"--verbose"** and **"--json"** will include a timestamp **e.g**: "1603971242534" property generated now in form of a timestamp, good for recording the metrics in some monitoring software.
+
 ## Links
 
 - [Product Hunt post](https://www.producthunt.com/posts/speed-test-cli)

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ $ speed-test --help
 ### Batch monitoring
 
 ```bash
-while true; do sleep 30; node cli.js -v -j; done >> ~/net.log
+while true; do sleep 30; node cli.js --verbose --json; done >> ~/net.log
 ```
 
 ## Links

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,9 @@ $ speed-test --help
     --verbose -v  Output more detailed information
 ```
 
-## Batch monitoring
+## Tips
+
+### Batch monitoring
 
 ```bash
 while true; do sleep 30; node cli.js -v -j; done >> ~/net.log


### PR DESCRIPTION
- Updated readme to include batch example
- The timestamp is only included via json argument and verbose all together, providing ability to monitor the results via some tool